### PR TITLE
fix: node matrix versions in github ci and actions updates

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,28 +1,32 @@
 name: Master
 
-on: [push]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+  push:
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [16]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm install and test
-      run: |
-        npm ci
-        npm run build
-        npm --prefix examples/ts-jest-ttypescript ci
-        npm --prefix examples/ts-jest-ttypescript test
-        npm --prefix examples/ts-jest-ttypescript run test:runInBand
-      env:
-        CI: true
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install and test
+        run: |
+          npm ci
+          npm run build
+          npm --prefix examples/ts-jest-ttypescript ci
+          npm --prefix examples/ts-jest-ttypescript test
+          npm --prefix examples/ts-jest-ttypescript run test:runInBand
+        env:
+          CI: true

--- a/examples/ts-jest-ts-patch/package-lock.json
+++ b/examples/ts-jest-ts-patch/package-lock.json
@@ -20,17 +20,18 @@
       }
     },
     "../..": {
-      "version": "2.0.0",
-      "integrity": "sha512-ybY/VtTWJUGDPhOLdjAXsM10ShO8ri1EorXpfHYg4CH00b/k30c4RJJ0iM7GQ4FakHsIr7/zTRwETd3N9smxoA==",
+      "version": "2.1.0",
+      "integrity": "sha512-ubL0pweKUHQNY2xCgwXjYllEQMgpKDojcEODpraQVevHqBFBsFDJZkpZp/2JsmujMu4TNJPzmSugXOLfKndmlQ==",
+      "license": "ISC",
       "devDependencies": {
-        "@types/jest": "^26.0.20",
-        "ts-auto-mock": "^3.1.0",
-        "ts-node": "^9.1.1",
-        "ttypescript": "^1.5.12",
-        "typescript": "^4.0.2"
+        "@types/jest": "^27.4.1",
+        "ts-auto-mock": "^3.5.0",
+        "ts-node": "^10.6.0",
+        "ttypescript": "^1.5.13",
+        "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "ts-auto-mock": "^3.1.0"
+        "ts-auto-mock": "^3.5.0"
       }
     },
     "../../node_modules/@jest/types": {
@@ -6996,11 +6997,11 @@
     "jest-ts-auto-mock": {
       "version": "file:../..",
       "requires": {
-        "@types/jest": "^26.0.20",
-        "ts-auto-mock": "^3.1.0",
-        "ts-node": "^9.1.1",
-        "ttypescript": "^1.5.12",
-        "typescript": "^4.0.2"
+        "@types/jest": "^27.4.1",
+        "ts-auto-mock": "^3.5.0",
+        "ts-node": "^10.6.0",
+        "ttypescript": "^1.5.13",
+        "typescript": "^4.3.5"
       },
       "dependencies": {
         "@jest/types": {

--- a/examples/ts-jest-ttypescript/package-lock.json
+++ b/examples/ts-jest-ttypescript/package-lock.json
@@ -20,8 +20,8 @@
       }
     },
     "../..": {
-      "version": "2.0.0",
-      "integrity": "sha512-ybY/VtTWJUGDPhOLdjAXsM10ShO8ri1EorXpfHYg4CH00b/k30c4RJJ0iM7GQ4FakHsIr7/zTRwETd3N9smxoA==",
+      "version": "2.1.0",
+      "integrity": "sha512-ubL0pweKUHQNY2xCgwXjYllEQMgpKDojcEODpraQVevHqBFBsFDJZkpZp/2JsmujMu4TNJPzmSugXOLfKndmlQ==",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "jest-ts-auto-mock",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.4.1",


### PR DESCRIPTION
I don't know what i have done in #45....
Trying to fix my mistakes 🙏 

1. I used node 16, and setup a github workflow so it would also run the tests for PR, not only on master. Also updated the actions already in place to latest versions
2. Re-ran npm install for each package.json, and added missing requiried peerdeps in one of the examples
